### PR TITLE
Update run to add dataset ECHOs

### DIFF
--- a/run
+++ b/run
@@ -162,14 +162,24 @@ if [ -e "groups/$POSITIONAL.bash" ]; then
 		if [ -e tests/$dataset.oat ]; then
 			# For each tag
 			for test_file in $(echo "tests/build/$dataset""_*.bats"); do
+				echo
 				echo Begin dataset: $dataset
-				echo Begin $dataset Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
-				echo Begin $dataset Free SWAP: $(awk '/SwapFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				printf '%0.s-' $(seq 1 $COLUMNS)
+				echo Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				echo Free SWAP: $(awk '/SwapFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				printf '%0.s-' $(seq 1 $COLUMNS)
+				echo
 				[ -e "$test_file" ] || continue
 				$BATS $test_file
+				echo
 				echo End dataset: $dataset
-				echo End $dataset Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
-				echo End $dataset Free SWAP: $(awk '/SwapFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				printf '%0.s-' $(seq 1 $COLUMNS)
+				echo Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				echo Free SWAP: $(awk '/SwapFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				printf '%0.s=' $(seq 1 $COLUMNS)
+				printf '%0.s=' $(seq 1 $COLUMNS)
+				echo
+				echo
 			done
 		else
 			echo "WARNING: tests/$dataset.oat does not exist. Ignoring."

--- a/run
+++ b/run
@@ -162,6 +162,7 @@ if [ -e "groups/$POSITIONAL.bash" ]; then
 		if [ -e tests/$dataset.oat ]; then
 			# For each tag
 			for test_file in $(echo "tests/build/$dataset""_*.bats"); do
+				main() {
 				echo
 				echo Begin dataset: $dataset
 				printf '%0.s-' $(seq 1 $COLUMNS)
@@ -176,6 +177,8 @@ if [ -e "groups/$POSITIONAL.bash" ]; then
 				printf '%0.s-' $(seq 1 $COLUMNS)
 				echo Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
 				echo Free SWAP: $(awk '/SwapFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				}
+				time main
 				printf '%0.s=' $(seq 1 $COLUMNS)
 				printf '%0.s=' $(seq 1 $COLUMNS)
 				echo

--- a/run
+++ b/run
@@ -164,10 +164,12 @@ if [ -e "groups/$POSITIONAL.bash" ]; then
 			for test_file in $(echo "tests/build/$dataset""_*.bats"); do
 				echo Begin dataset: $dataset
 				echo Begin $dataset Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				echo Begin $dataset Free SWAP: $(awk '/SwapFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
 				[ -e "$test_file" ] || continue
 				$BATS $test_file
 				echo End dataset: $dataset
 				echo End $dataset Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
+				echo End $dataset Free SWAP: $(awk '/SwapFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
 			done
 		else
 			echo "WARNING: tests/$dataset.oat does not exist. Ignoring."

--- a/run
+++ b/run
@@ -163,9 +163,11 @@ if [ -e "groups/$POSITIONAL.bash" ]; then
 			# For each tag
 			for test_file in $(echo "tests/build/$dataset""_*.bats"); do
 				echo Begin dataset: $dataset
+				echo Begin $dataset Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
 				[ -e "$test_file" ] || continue
 				$BATS $test_file
 				echo End dataset: $dataset
+				echo End $dataset Free Memory: $(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024 }' /proc/meminfo)GB
 			done
 		else
 			echo "WARNING: tests/$dataset.oat does not exist. Ignoring."

--- a/run
+++ b/run
@@ -34,7 +34,7 @@ case $key in
     export DOCKER_IMAGE="$2"
     shift # past argument
     shift # past value
-    ;;	
+    ;;
     --options)
     export CMD_OPTIONS="$2"
     shift # past argument
@@ -78,7 +78,7 @@ usage(){
   	source $group
   	echo "	$(basename $group .bash)	${DATASETS[@]}"
   done
-  echo 
+  echo
   echo "Options:"
   echo "	--datasets <dataset1,dataset2,...>	Test only the specified datasets from the group"
   echo "	--tags	<tag1,tag2,...>	docker tag images to test. Each tag is tested against each dataset. (default: latest)"
@@ -137,7 +137,7 @@ if [ "$HELP" == "YES" ]; then
 fi
 
 if [ "$NUKE" == "YES" ]; then
-	rm -vfr results/* datasets/* tests/build/* 
+	rm -vfr results/* datasets/* tests/build/*
 	exit 0
 fi
 
@@ -162,11 +162,13 @@ if [ -e "groups/$POSITIONAL.bash" ]; then
 		if [ -e tests/$dataset.oat ]; then
 			# For each tag
 			for test_file in $(echo "tests/build/$dataset""_*.bats"); do
+				echo Begin dataset: $dataset
 				[ -e "$test_file" ] || continue
 				$BATS $test_file
+				echo End dataset: $dataset
 			done
 		else
-			echo "WARNING: tests/$dataset.oat does not exist. Ignoring." 
+			echo "WARNING: tests/$dataset.oat does not exist. Ignoring."
 		fi
 	done
 else


### PR DESCRIPTION
Added informational ECHO statements for beginning and end of each OATS dataset, to help the user differentiate what tests are running in the terminal output.

Example output after changes:  

```
solus@elitebook-2740p ~/oats $ ./run all
Begin dataset: banana
 ✗ default with dsm
   (from function `run_test' in file tests/build/functions.bash, line 60,
    in test file tests/build/banana_latest.bats, line 5)
     `run_test "--dsm" "latest"' failed with status 126
   docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.40/containers/create": dial unix /var/run/docker.sock: connect: permission denied.
   See 'docker run --help'.

1 test, 1 failure
End dataset: banana

```