### PR TITLE
Add a new test for most of the untested flags

### DIFF
--- a/run
+++ b/run
@@ -97,6 +97,7 @@ environment_check(){
 	check_command "sed" "Run \033[1msudo apt install -y sed\033[0m" "sudo apt install -y sed"
 	check_command "unzip" "Run \033[1msudo apt install -y unzip\033[0m" "sudo apt install -y unzip"
 	check_command "jq" "Run \033[1msudo apt install -y jq\033[0m" "sudo apt install -y jq"
+	check_command "gdalinfo" "Run \033[1msudo apt install -y gdal-bin\033[0m" "sudo apt install -y gdal-bin"
 }
 
 ensure_bats(){

--- a/tests/brighton.oat
+++ b/tests/brighton.oat
@@ -24,8 +24,7 @@ DATASET_URL=https://github.com/OpenDroneMap/drone_dataset_brighton_beach/archive
 }
 
 # Every ODM flag that is a boolean path toggle or an additive output, to cover
-# as much of the pipeline as one run can. Values and tuning knobs are out of
-# scope here, they belong in a parameter test of their own.
+# as much of the pipeline as one run can.
 #
 # Flags left out on purpose:
 #   --cog                        build_overviews is skipped when --cog is set
@@ -37,8 +36,8 @@ DATASET_URL=https://github.com/OpenDroneMap/drone_dataset_brighton_beach/archive
 #   --boundary                   overrides --auto-boundary
 #   --ignore-gsd                 changes resolutions rather than paths
 #   --skip-report                drops report outputs
-# --orthophoto-cutline turns --crop on by itself (ODM sets it to 0.01).
-@test "kitchen sink" {
+#   --orthophoto-cutline turns --crop on by itself (ODM sets it to 0.01).
+@test "all flags" {
   $run_test "--dsm --dtm --gltf --tiles --orthophoto-png --orthophoto-kmz --orthophoto-cutline --orthophoto-no-tiled --pc-las --pc-csv --pc-copc --pc-rectify --pc-skip-geometric --dem-euclidean-map --use-3dmesh --texturing-keep-unseen-faces --texturing-skip-global-seam-leveling --build-overviews --auto-boundary --use-hybrid-bundle-adjustment --use-fixed-camera-params"
 
   [ -e "$output_dir/odm_texturing/odm_textured_model_geo.glb" ]

--- a/tests/brighton.oat
+++ b/tests/brighton.oat
@@ -23,6 +23,48 @@ DATASET_URL=https://github.com/OpenDroneMap/drone_dataset_brighton_beach/archive
   [ -e "$output_dir/odm_orthophoto/odm_orthophoto.tif" ]
 }
 
+# Every ODM flag that is a boolean path toggle or an additive output, to cover
+# as much of the pipeline as one run can. Values and tuning knobs are out of
+# scope here, they belong in a parameter test of their own.
+#
+# Flags left out on purpose:
+#   --cog                        build_overviews is skipped when --cog is set
+#   --texturing-single-material  the packing step wipes odm_texturing, taking
+#                                the --gltf output with it
+#   --skip-orthophoto            removes the orthophoto the other flags act on
+#   --fast-orthophoto            skips the 3D mesh and the DEM path
+#   --use-exif                   ignores the GCP/geo path
+#   --boundary                   overrides --auto-boundary
+#   --ignore-gsd                 changes resolutions rather than paths
+#   --skip-report                drops report outputs
+# --orthophoto-cutline turns --crop on by itself (ODM sets it to 0.01).
+@test "kitchen sink" {
+  $run_test "--dsm --dtm --gltf --tiles --orthophoto-png --orthophoto-kmz --orthophoto-cutline --orthophoto-no-tiled --pc-las --pc-csv --pc-copc --pc-rectify --pc-skip-geometric --dem-euclidean-map --use-3dmesh --texturing-keep-unseen-faces --texturing-skip-global-seam-leveling --build-overviews --auto-boundary --use-hybrid-bundle-adjustment --use-fixed-camera-params"
+
+  [ -e "$output_dir/odm_texturing/odm_textured_model_geo.glb" ]
+
+  [ -e "$output_dir/odm_orthophoto/odm_orthophoto.tif" ]
+  [ -e "$output_dir/odm_orthophoto/odm_orthophoto.png" ]
+  [ -e "$output_dir/odm_orthophoto/odm_orthophoto.kmz" ]
+  [ -e "$output_dir/odm_orthophoto/cutline.gpkg" ]
+
+  [ -e "$output_dir/odm_georeferencing/odm_georeferenced_model.laz" ]
+  [ -e "$output_dir/odm_georeferencing/odm_georeferenced_model.las" ]
+  [ -e "$output_dir/odm_georeferencing/odm_georeferenced_model.csv" ]
+  [ -e "$output_dir/odm_georeferencing/odm_georeferenced_model.copc.laz" ]
+
+  [ -e "$output_dir/odm_dem/dsm.tif" ]
+  [ -e "$output_dir/odm_dem/dtm.tif" ]
+  [ -e "$output_dir/odm_dem/dsm.euclideand.tif" ]
+  [ -e "$output_dir/odm_dem/dtm.euclideand.tif" ]
+
+  [ -e "$output_dir/orthophoto_tiles" ]
+  [ -e "$output_dir/dsm_tiles" ]
+  [ -e "$output_dir/dtm_tiles" ]
+
+  gdalinfo "$output_dir/odm_orthophoto/odm_orthophoto.tif" | grep -q Overviews
+}
+
 @test "GeoTIFF alignment" {
   $run_test "--align /datasets/code/dsm.tif --skip-3dmodel"
   [ -e "$output_dir/opensfm/stats/codem/registration.json" ]


### PR DESCRIPTION
We missed https://github.com/OpenDroneMap/ODM/pull/2059 because we didn't test that flag in oats.

Looking deeper, ODM has roughly 91 flags in total and we currently test only 21 of them. Some of these are just changes to default variables, metadata (e.g. `--version`), or skipping certain outputs, but a few of them are just untested paths.

This PR does two things:

1. It adds a "kitchen sink" test where we run as many flags as we can without conflicts. This takes us from 21/91 to 40/91. 
```bash
--dsm --dtm --gltf --tiles --orthophoto-png --orthophoto-kmz --orthophoto-cutline --orthophoto-no-tiled --pc-las --pc-csv --pc-copc --pc-rectify --pc-skip-geometric --dem-euclidean-map --use-3dmesh --texturing-keep-unseen-faces --texturing-skip-global-seam-leveling --build-overviews --auto-boundary --use-hybrid-bundle-adjustment --use-fixed-camera-params
```
2. Added `gdalinfo` as a requirement so we can check the orthophoto includes the overviews generated by `--build-overviews`. 

At some point we might want to split these out into separate tests as the cost of speed/size, but for now this works and gives a quick "did this pass". The exact reason it failed can still be derived from the output log. 