### PR TITLE
Cover radiometric calibration in the micasense tests

### DIFF
--- a/tests/micasense.oat
+++ b/tests/micasense.oat
@@ -15,3 +15,13 @@ DATASET_URL=https://github.com/OpenDroneMap/drone_dataset_micasense/archive/main
   $run_test "--fast-orthophoto --min-num-features 15000 --matcher-type bow"
   [ -e "$output_dir/odm_orthophoto/odm_orthophoto.tif" ]
 }
+
+@test "radiometric calibration camera" {
+  $run_test "--radiometric-calibration camera --fast-orthophoto --min-num-features 15000 --matcher-type bow"
+  [ -e "$output_dir/odm_orthophoto/odm_orthophoto.tif" ]
+}
+
+@test "radiometric calibration camera+sun" {
+  $run_test "--radiometric-calibration camera+sun --fast-orthophoto --min-num-features 15000 --matcher-type bow"
+  [ -e "$output_dir/odm_orthophoto/odm_orthophoto.tif" ]
+}


### PR DESCRIPTION
Add a test to cover the case in https://github.com/OpenDroneMap/ODM/issues/2064 and the fix in https://github.com/OpenDroneMap/ODM/pull/2066

The suite exercised multispectral band alignment but never `--radiometric-calibration`, leaving the reflectance conversion untested. Both modes are added since only `camera+sun` goes through the sun sensor irradiance estimate.

@smathermather the reported bug used a different dataset but it was 15GB or something. I believe the micasense dataset is also multispectral but I'm not entirely certain this makes sense. It does fail without the fix and pass with it, but that doesn't necessarily mean its correct.